### PR TITLE
Restrict compatible node versions to ^8.17

### DIFF
--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -85,8 +85,8 @@ After build staging it is the `lib` folder which actually gets published to NPM.
 ## NPM/Node Version Requirements
 
 `ethjs` requires you have:
-  - `nodejs` -v 6.5.0+
-  - `npm` -v 3.0+
+  - `nodejs` -v 8.17.0+
+  - `npm` -v 6.0+
 
 This is a requirement to run, test, lint and build this module.
 

--- a/package.json
+++ b/package.json
@@ -143,8 +143,8 @@
     "webpack": "2.1.0-beta.15"
   },
   "engines": {
-    "node": ">=6.5.0",
-    "npm": ">=3"
+    "node": "^8.17.0",
+    "npm": ">=6"
   },
   "eslintConfig": {
     "parser": "babel-eslint",


### PR DESCRIPTION
Installing and building native dependencies for this package fails on Node.js v10 and newer. Therefore this will exclusively support only Node.js v8, until this has been resolved.

#### Blocking
- #3 
- #4 
  - #6 
- #5