### PR TITLE
deps: add missing promise-to-callback from devDeps

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4604,8 +4604,7 @@
     "is-fn": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-fn/-/is-fn-1.0.0.tgz",
-      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw=",
-      "dev": true
+      "integrity": "sha1-lUPV3nvPWwiiLsiiC65uKG1RDYw="
     },
     "is-fullwidth-code-point": {
       "version": "1.0.0",
@@ -6421,7 +6420,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/promise-to-callback/-/promise-to-callback-1.0.0.tgz",
       "integrity": "sha1-XSp0kBC/tn2WNZj805YHRqaP7vc=",
-      "dev": true,
       "requires": {
         "is-fn": "^1.0.0",
         "set-immediate-shim": "^1.0.1"
@@ -6987,8 +6985,7 @@
     "set-immediate-shim": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E=",
-      "dev": true
+      "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
     },
     "set-value": {
       "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -78,11 +78,12 @@
   },
   "bundleDependencies": false,
   "dependencies": {
+    "babel-runtime": "^6.26.0",
     "ethjs-abi": "0.2.0",
     "ethjs-filter": "0.1.8",
     "ethjs-util": "0.1.3",
     "js-sha3": "0.5.5",
-    "babel-runtime": "^6.26.0"
+    "promise-to-callback": "^1.0.0"
   },
   "deprecated": false,
   "description": "A simple contract object for the Ethereum RPC.",
@@ -137,7 +138,6 @@
     "lint-staged": "1.0.1",
     "mocha": "3.1.2",
     "pre-commit": "1.1.3",
-    "promise-to-callback": "^1.0.0",
     "rimraf": "2.3.4",
     "webpack": "2.1.0-beta.15"
   },


### PR DESCRIPTION
The package `promise-to-callback` is actually used as a runtime dependency. This moves it into `dependencies` from `devDependencies`.

#### Blocked by
- [x] #3 
  - [x] #2 