### PR TITLE
deps: ethjs-abi@0.2.0->^0.2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@metamask/ethjs-filter": "^0.2.0",
     "@metamask/ethjs-util": "^0.2.0",
     "babel-runtime": "^6.26.0",
-    "ethjs-abi": "0.2.0",
+    "ethjs-abi": "^0.2.0",
     "js-sha3": "^0.9.2",
     "promise-to-callback": "^1.0.0"
   },


### PR DESCRIPTION
- unpin `ethjs-abi` to allow both published versions 0.2.0 and 0.2.1

#### Blocking
- #20
  - #6
    - #15