### PR TITLE
devDeps: @metamask/ethjs-query@^0.5.1->^0.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -861,47 +861,42 @@
       "integrity": "sha512-uXTIsJXQhMylX/cs2Z5J4hVVLTajoWOw+dVwLjWt221HO/pwWATJSjpMYsdWQul0slLSLQMIYlFUGOtDxZkh+Q=="
     },
     "@metamask/ethjs-format": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-format/-/ethjs-format-0.2.9.tgz",
-      "integrity": "sha512-jqtUTh/mqzUH/BIBLfnpjVse7zl428+Gnubn6EmAqJFk19PT7Nbw5X+FzvuDh3xkXXF0KXW1DNlxnfMDjrm3sg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-format/-/ethjs-format-0.3.0.tgz",
+      "integrity": "sha512-Q0FhY/e7XYmP4y7qMhM3Fv86Z0kO+mont8BqBogDMOMvSa8bzjPy94XRKHarIcYICyCL9Kp2zGHVTuQR2J+JtA==",
       "dev": true,
       "requires": {
-        "@metamask/ethjs-util": "^0.2.0",
-        "bn.js": "4.11.6",
+        "@metamask/ethjs-util": "^0.3.0",
+        "@metamask/number-to-bn": "^1.7.1",
+        "bn.js": "^5.2.1",
         "ethjs-schema": "0.2.1",
         "is-hex-prefixed": "1.0.0",
-        "number-to-bn": "1.7.0",
         "strip-hex-prefix": "1.0.0"
       },
       "dependencies": {
-        "@metamask/ethjs-util": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/@metamask/ethjs-util/-/ethjs-util-0.2.0.tgz",
-          "integrity": "sha512-i7kPlhnk2Doz7tQd90frh0WtrKS5FbYfQw2npYd3dVx5rhbvUjhyz7T/coVZSP3QDbszyzD3xmC50OxBmZou3Q==",
-          "dev": true,
-          "requires": {
-            "is-hex-prefixed": "1.0.0",
-            "strip-hex-prefix": "1.0.0"
-          }
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+          "dev": true
         }
       }
     },
     "@metamask/ethjs-query": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-query/-/ethjs-query-0.5.3.tgz",
-      "integrity": "sha512-hSttg1b3CNzSiixFJjHc1B0JEbMag7RpGwUqReE3SDXfVQJvS8qR3GQhaI3nhMrD8nvXThxYPBxC5TLbGRqdTg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-query/-/ethjs-query-0.7.1.tgz",
+      "integrity": "sha512-ctyFom36AHq/6TW1CECOB0m/ESxVD24szkeLXFOnJ/5mlICA5bUEC62AUedAEF8pqVgbxhDkr1gwEwXn6W/j0Q==",
       "dev": true,
       "requires": {
-        "@metamask/ethjs-format": "^0.2.9",
-        "@metamask/ethjs-rpc": "0.3.0 || ^0.3.2",
-        "babel-runtime": "^6.26.0",
+        "@metamask/ethjs-format": "^0.3.0",
+        "@metamask/ethjs-rpc": "^0.4.0",
         "promise-to-callback": "^1.0.0"
       }
     },
     "@metamask/ethjs-rpc": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.3.2.tgz",
-      "integrity": "sha512-GnMq498r6zcWYfVpO4IdxX0kjFygVg/GP86TpAvTTi7WVhXH49u26f3/SH/F4ZWvoenWLyRdTGpkVFO82Aaz/A==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@metamask/ethjs-rpc/-/ethjs-rpc-0.4.0.tgz",
+      "integrity": "sha512-lKTQfIXOyWsbGf9QqGaA6RnLcyvEeBPk5kAs1dXfWDpWL8+9TE0PbhPDQGjfn5Z9MFWEelJ2HD251wk0jAxD2A==",
       "dev": true,
       "requires": {
         "promise-to-callback": "^1.0.0"
@@ -914,6 +909,24 @@
       "requires": {
         "is-hex-prefixed": "1.0.0",
         "strip-hex-prefix": "1.0.0"
+      }
+    },
+    "@metamask/number-to-bn": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@metamask/number-to-bn/-/number-to-bn-1.7.1.tgz",
+      "integrity": "sha512-qCN+Au4amvcVii2LdOJNndYhdmk5Lk9tlStJhKpZ8tGeYQDJTghqYXJuSUVPHvfl6FUfKY1i1Or2j2EbnEerSQ==",
+      "dev": true,
+      "requires": {
+        "bn.js": "5.2.1",
+        "strip-hex-prefix": "1.0.0"
+      },
+      "dependencies": {
+        "bn.js": {
+          "version": "5.2.1",
+          "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
+          "integrity": "sha512-eXRvHzWyYPBuB4NBy0cmYQjGitUrtqwbvlzP3G6VFnNRbsZQIxQ10PbKKHt8gZ/HW/D/747aDl+QkDqg3KQLMQ==",
+          "dev": true
+        }
       }
     },
     "@nicolo-ribaudo/chokidar-2": {
@@ -1503,24 +1516,6 @@
       "dev": true,
       "requires": {
         "@babel/helper-define-polyfill-provider": "^0.4.3"
-      }
-    },
-    "babel-runtime": {
-      "version": "6.26.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "^2.4.0",
-        "regenerator-runtime": "^0.11.0"
-      },
-      "dependencies": {
-        "regenerator-runtime": {
-          "version": "0.11.1",
-          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-          "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-          "dev": true
-        }
       }
     },
     "balanced-match": {
@@ -2160,12 +2155,6 @@
       "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
       "dev": true,
       "optional": true
-    },
-    "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-      "dev": true
     },
     "core-js-compat": {
       "version": "3.33.3",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
   "deprecated": false,
   "description": "A simple contract object for the Ethereum RPC.",
   "devDependencies": {
-    "@metamask/ethjs-query": "^0.5.1",
+    "@metamask/ethjs-query": "^0.7.1",
     "@babel/cli": "^7.0.0",
     "@babel/core": "^7.0.0",
     "@babel/eslint-parser": "^7.11.0",
@@ -115,7 +115,6 @@
     "@babel/register": "^7.0.0",
     "async": "^2.6.4",
     "babel-loader": "^8.0.0",
-    "babel-runtime": "^6.26.0",
     "chai": "^4.3.10",
     "cross-env": "^6.0.3",
     "eslint": "^5.4.0",


### PR DESCRIPTION
- Update version of `@metamask/ethjs-query` used in tests to latest
  - Remove devDependency `babel-runtime`

#### Blocked by
- [x] #21